### PR TITLE
Bug Fix - Client Menu not updating properly

### DIFF
--- a/user_scripts/mp/trickshotmenu1/chinchilla/joey.gsc
+++ b/user_scripts/mp/trickshotmenu1/chinchilla/joey.gsc
@@ -376,25 +376,30 @@ addOption(menu, index, text, func, arg1, arg2)
         self.menus[menu][index].arg2 = arg2;
 }
 
-newMenu(menu, fade)
+newMenu(menu)
 {
     foreach(text in self.menutext)
     {
         text destroy();
     }
+	// clear existing menu variable
+	self.menus[menu] = undefined;
+
 	self thread loadMenus();
     self.lastscroll[self.current] = self.scroll;
-    if(!isDefined(self.lastscroll[menu]))
+    if(!isDefined(self.lastscroll[menu]))	
         self.scroll = 0;
     else
         self.scroll = self.lastscroll[menu];
 
-    self.current = menu;
-    self.title setSafeText(menu);
+	self.current = menu;
+	self.title setSafeText(menu);
+
     for(i=0;i<self.menus[menu].size;i++)
     {
         self.menutext[i] = self createText("objective", 1.4, "LEFT", "CENTER", -80, -45 + i * 15, 2, (1,1,1), 1, self.menus[menu][i].text);
     }
+
     self thread updateScroll();
     self thread updateBase();
 }


### PR DESCRIPTION
The client menu was not staying up to date when a player was kicked or when a player disconnected. They were still being shown on the menu. This was due to the self.menus[menu] array not being set to undefined when with the self.menutext items were destroyed from the HUD inside the newMenu function. 

I've added the simple fix to do this which should also improve the menu's performance as well. 