### PR TITLE
bot streaks, weapon pickups, infinite nukes

### DIFF
--- a/user_scripts/mp/enable_bot_killstreaks/README.md
+++ b/user_scripts/mp/enable_bot_killstreaks/README.md
@@ -1,0 +1,50 @@
+Script files to enable multiplayer bots to gain and deploy various killstreaks in-game.
+
+Stable version 1.0 Github Repo: https://github.com/LogicalLeap/enable_bot_killstreaks
+Github pre-release for the new experimental version: https://github.com/LogicalLeap/enable_bot_killstreaks/releases/tag/experimental
+
+If anyone has any feedback or requests feel free to let me know. I might add more killstreak loadout possibilities for the bots and even enable them to use nukes if anyone is interested.
+
+
+*** Bot Killstreaks by Sly Elliot ***
+
+
+/// HOW TO INSTALL v1.0 /// 
+
+These two files are for server hosts or local private match players to enable bots in multiplayer to use killstreaks.
+
+Drop the enable_bot_killstreaks.gsc file into your user scripts folder located at:
+user_scripts\mp
+
+Replace your current _hardpoints.gsc file with the new one from this download. _hardpoints.gsc is located in:
+h2m-mod\maps\mp\gametypes
+
+
+
+/// COMPATIBILITY /// 
+
+I've tested this for compatibility with:
+
+- AutoBotsWithDifficultyH2M
+
+- changeteamFixH2
+
+- nuke_to_moab_patch_v2.1.1
+
+- teambalanceH2
+
+- H1Mapvote
+
+
+
+/// HOW TO INSTALL v1.1.2 Experimental ///
+
+drop enable_bot_killstreaks.gsc in your user_scripts
+
+drop _hardpoints.gsc in your h2m-mod\maps\mp\gametypes and replace the file there
+
+drop bot_patches.gsc in your h2m-mod\scripts\mp and replace the file there
+
+
+
+

--- a/user_scripts/mp/enable_bot_killstreaks/_hardpoints.gsc
+++ b/user_scripts/mp/enable_bot_killstreaks/_hardpoints.gsc
@@ -1,0 +1,729 @@
+//modified by Cpt.Price141
+#include scripts\utility;
+
+#define DISABLE_BOT_KILLSTREAKS 0
+
+h2_setCustomKillstreaks()
+{
+	index_0 = self getPlayerData( "rankedMatchData", "sosRating" );
+	index_1 = self getPlayerData( "rankedMatchData", "gdfVariance" );
+	index_2 = self getPlayerData( "rankedMatchData", "gdfRating" );
+
+	if( isBot( self ) )
+	{
+		if( !DISABLE_BOT_KILLSTREAKS )
+		{
+			self.customKillstreaks = [];
+			self scripts\mp\bot_patches::h2_set_bot_ks();
+		}
+	}
+	else
+	{
+		self.customKillstreaks = [];
+		self.customKillstreaks[0] = h2_getStreakNameFromIndex( index_0, 0 );
+		self.customKillstreaks[1] = h2_getStreakNameFromIndex( index_1, 1 );
+		self.customKillstreaks[2] = h2_getStreakNameFromIndex( index_2, 2 );
+	}
+
+	for ( i = 1; i < self.customKillstreaks.size; i++ ) //order the killstreaks by their cost
+	{
+		streakName = self.customKillstreaks[i];
+		streakCost = level.hardpointitems[streakName];
+
+		for ( j = i - 1; j >= 0 && streakCost < level.hardpointitems[self.customKillstreaks[j]]; j-- )
+			self.customKillstreaks[j + 1] = self.customKillstreaks[j];
+
+		self.customKillstreaks[j + 1] = streakName;
+	}
+}
+
+h2_isKillstreakActivator( weapon )
+{
+	return( isDefined( level.h2_isKillstreakActivator[weapon] ) );
+}
+
+h2_getStreakNameFromIndex( index, number )
+{
+	index = int(index);
+	switch( index )
+	{
+	case 1:
+		return "radar_mp";
+	case 2:
+		return "airdrop_marker_mp";
+	case 3:
+		return "counter_radar_mp";
+	case 4:
+		return "sentry_mp";
+	case 5:
+		return "predator_mp";
+	case 6:
+		return "airstrike_mp";
+	case 7:
+		return "helicopter_mp";
+	case 8:
+		return "harrier_airstrike_mp";
+	case 9:
+		return "airdrop_mega_marker_mp";
+	case 10:
+		return "pavelow_mp";
+	case 11:
+		return "stealth_airstrike_mp";
+	case 12:
+		return "chopper_gunner_mp";
+	case 13:
+		return "ac130_mp";
+	case 14:
+		return "emp_mp";
+	case 15:
+		return "nuke_mp";
+
+	default:
+		if( number == 0 )
+			return "radar_mp";
+		else if( number == 1 )
+			return "airdrop_marker_mp";
+		else
+			return "predator_mp";
+	}
+}
+
+init()
+{
+	game["thermal_vision"] = "thermal_mp";
+
+	level.killstreaksenabled = 1;
+
+	level.hardpointitems = [];
+	level.hardpointitems["radar_mp"] = getdvarint( "scr_killstreak_kills_uav", 3 );
+	level.hardpointitems["counter_radar_mp"] = getdvarint( "scr_killstreak_kills_counter_uav", 4 );
+	level.hardpointitems["airdrop_marker_mp"] = getdvarint( "scr_killstreak_kills_airdrop", 4 );
+	level.hardpointitems["sentry_mp"] = getdvarint( "scr_killstreak_kills_sentry", 5 );
+	level.hardpointitems["predator_mp"] = getdvarint( "scr_killstreak_kills_predator", 5 );
+	level.hardpointitems["airstrike_mp"] = getdvarint( "scr_killstreak_kills_precision_airstrike", 6 );
+	level.hardpointitems["harrier_airstrike_mp"] = getdvarint( "scr_killstreak_kills_harrier", 7 );
+	level.hardpointitems["helicopter_mp"] = getdvarint( "scr_killstreak_kills_heli", 7 );
+	level.hardpointitems["airdrop_mega_marker_mp"] = getdvarint( "scr_killstreak_kills_airdrop_mega", 8 );
+	level.hardpointitems["stealth_airstrike_mp"] = getdvarint( "scr_killstreak_kills_stealth", 9 );
+	level.hardpointitems["pavelow_mp"] = getdvarint( "scr_killstreak_kills_pavelow", 9 );
+	level.hardpointitems["chopper_gunner_mp"] = getdvarint( "scr_killstreak_kills_chopper", 11 );
+	level.hardpointitems["ac130_mp"] = getdvarint( "scr_killstreak_kills_ac130", 11 );
+	level.hardpointitems["emp_mp"] = getdvarint( "scr_killstreak_kills_emp", 15 );
+	level.hardpointitems["nuke_mp"] = getdvarint( "scr_killstreak_kills_nuke", 25 );
+	//level.hardpointitems["dogs_mp"] = 10;
+
+	level.killstreakwieldweapons["artillery_mp"] = "airstrike_mp";
+	level.killstreakwieldweapons["cobra_ffar_mp"] = "helicopter_mp";
+	level.killstreakwieldweapons["hind_ffar_mp"] = "helicopter_mp";
+	level.killstreakwieldweapons["cobra_20mm_mp"] = "helicopter_mp";
+	level.killstreakwieldweapons["cobra_player_minigun_mp"] = "chopper_gunner_mp";
+	level.killstreakwieldweapons["stealth_bomb_mp"] = "stealth_airstrike_mp";
+	level.killstreakwieldweapons["pavelow_minigun_mp"] = "pavelow_mp";
+	level.killstreakwieldweapons["harrier_20mm_mp"] = "harrier_airstrike_mp";
+	level.killstreakwieldweapons["harrier_ffar_mp"] = "harrier_airstrike_mp";
+	level.killstreakwieldweapons["ac130_105mm_mp"] = "ac130_mp";
+	level.killstreakwieldweapons["ac130_40mm_mp"] = "ac130_mp";
+	level.killstreakwieldweapons["ac130_25mm_mp"] = "ac130_mp";
+	level.killstreakwieldweapons["remotemissile_projectile_mp"] = "predator_mp";
+	level.killstreakwieldweapons["sentry_minigun_mp"] = "sentry_mp";
+	level.killstreakwieldweapons["nuke_mp"] = "nuke_mp";
+	level.killstreakwieldweapons["dogs_mp"] = "dogs_mp";
+
+	level.maxkillstreakforaward = 0;
+
+	foreach ( streakName, streakCost in level.hardpointitems )
+	{
+		if ( level.maxkillstreakforaward < streakCost )
+			level.maxkillstreakforaward = streakCost;
+
+		level.h2_isKillstreakActivator[streakName] = true;
+
+		// lots of errors come from this, are we sure its needed? killstreaks work in game just fine for me still
+		//precacheItem( streakName );
+
+		precacheShader( getkillstreakcrateicon( streakName ) );
+
+		maps\mp\gametypes\_rank::registerxpeventinfo( streakName + "_earned", 100 );
+	}
+
+	precachestring( &"MP_KILLSTREAK_N" );
+
+	level.numhardpointreservedobjectives = 0;
+
+	level.killstreakfuncs = [];
+
+	level.killstreakrounddelay = maps\mp\_utility::getintproperty( "scr_game_killstreakdelay", 0 );
+	level.killcountpersistsoverrounds = maps\mp\_utility::getintproperty( "scr_killcount_persists", 1 );
+
+	level.killStreakSpecialCaseWeapons = [];
+	level.killStreakSpecialCaseWeapons["cobra_player_minigun_mp"] = true;
+	level.killStreakSpecialCaseWeapons["artillery_mp"] = true;
+	level.killStreakSpecialCaseWeapons["stealth_bomb_mp"] = true;
+	level.killStreakSpecialCaseWeapons["pavelow_minigun_mp"] = true;
+	level.killStreakSpecialCaseWeapons["sentry_minigun_mp"] = true;
+	level.killStreakSpecialCaseWeapons["harrier_20mm_mp"] = true;
+	level.killStreakSpecialCaseWeapons["ac130_105mm_mp"] = true;
+	level.killStreakSpecialCaseWeapons["ac130_40mm_mp"] = true;
+	level.killStreakSpecialCaseWeapons["ac130_25mm_mp"] = true;
+	level.killStreakSpecialCaseWeapons["remotemissile_projectile_mp"] = true;
+	level.killStreakSpecialCaseWeapons["cobra_20mm_mp"] = true;
+	level.killStreakSpecialCaseWeapons["cobra_ffar_mp"] = true;
+	level.killStreakSpecialCaseWeapons["hind_ffar_mp"] = true;
+	level.killStreakSpecialCaseWeapons["dogs_mp"] = true;
+
+	registerDialog( "ac130_mp", "ac130" );
+	registerDialog( "airstrike_mp", "airstrike" );
+	registerDialog( "stealth_airstrike_mp", "airstrike" );
+	registerDialog( "airdrop_marker_mp", "carepackage" );
+	registerDialog( "airdrop_mega_marker_mp", "emergairdrop" );
+	registerDialog( "emp_mp", "emp" );
+	registerDialog( "harrier_airstrike_mp", "harriers" );
+	registerDialog( "chopper_gunner_mp", "heli" );
+	registerDialog( "helicopter_mp", "cobra" );
+	registerDialog( "counter_radar_mp", "jamuav" );
+	registerDialog( "nuke_mp", "nuke" );
+	registerDialog( "pavelow_mp", "pavelow" );
+	registerDialog( "predator_mp", "predator" );
+	registerDialog( "sentry_mp", "sentrygun" );
+	registerDialog( "radar_mp", "uav" );
+
+	level thread onplayerconnect();
+
+	thread maps\mp\_helicopter::init();
+	thread maps\mp\h2_killstreaks\_autosentry::init();
+	thread maps\mp\h2_killstreaks\_remotemissile::init();
+	thread maps\mp\h2_killstreaks\_ac130::init();
+	thread maps\mp\h2_killstreaks\_emp::init();
+	thread maps\mp\h2_killstreaks\_nuke::init();
+	thread maps\mp\h2_killstreaks\_airdrop::init();
+	thread maps\mp\h2_killstreaks\_airstrike::init();
+	thread maps\mp\h2_killstreaks\_uav::init();
+	thread maps\mp\h2_killstreaks\_airstrike::init();
+
+	if ( getdvarint( "sv_cheats" ) )
+		thread developer_dvars();
+}
+
+registerDialog( streakName, string )
+{
+	game["dialog"]["achieve_" + streakName] = "achieve_" + string;
+
+	if ( string == "nuke" )
+		string = "tnuke";
+
+	game["dialog"]["use_" + streakName] = "use_" + string;
+	game["dialog"]["enemy_" + streakName] = "enemy_" + string;
+}
+
+developer_dvars()
+{
+	level endon("game_ended");
+	level endon("shutdownGame_called");
+
+	setDvar( "gks", "" );
+	setDvar( "gpk", "" );
+	setDvar( "gbks", "" );
+
+	for( ;; )
+	{
+		wait 0.05;
+
+		if ( getDvar( "gks" ) != "" )
+		{						
+			level.players[0] thread giveHardpoint( getDvar( "gks" ) );	
+
+			setDvar( "gks", "" );
+		}
+
+		if ( getDvar( "gbks" ) != "" )
+		{						
+			level.players[1] thread giveHardpoint( getDvar( "gbks" ) );	
+
+			setDvar( "gbks", "" );
+		}
+
+		if ( getDvar( "gpk" ) != "" )
+		{						
+			level.players[0] maps\mp\_utility::_setPerk( getDvar( "gpk" ), 0 );
+
+			setDvar( "gpk", "" );
+		}
+	}
+}
+
+onplayerconnect()
+{
+	level endon("game_ended");
+
+	for (;;)
+	{
+		level waittill( "connected", player ); 
+
+		if ( isBot(player) && DISABLE_BOT_KILLSTREAKS )
+			continue;
+
+		player h2_setCustomKillstreaks();
+
+		if ( !level.teambased )
+			level.activeuavs[player.guid] = 0;
+
+		if ( !isDefined ( player.pers[ "killstreaks" ] ) )
+			player.pers[ "killstreaks" ] = [];
+
+		if ( !isDefined ( player.pers[ "kID" ] ) )
+			player.pers[ "kID" ] = 10;
+
+		if ( !isDefined ( player.pers[ "kIDs_valid" ] ) )
+			player.pers[ "kIDs_valid" ] = [];
+
+		player.lifeId = 0;
+
+		if ( isDefined( player.pers["deaths"] ) )
+			player.lifeId = player.pers["deaths"];
+	}
+}
+
+waitForChangeTeam()
+{
+	self endon ( "disconnect" );
+
+	self notify( "waitForChangeTeam" );
+	self endon( "waitForChangeTeam" );
+
+	level endon("game_ended");
+
+	for ( ;; )
+	{
+		self waittill( "joined_team" );
+
+		if( isDefined( self.pers["killstreaks"] ) )
+		{
+			foreach ( index, streakStruct in self.pers["killstreaks"] )
+				self.pers["killstreaks"][index] = undefined;
+		}
+	}
+}
+
+givehardpointitemforstreak()
+{
+	if ( isBot(self) && DISABLE_BOT_KILLSTREAKS )
+		return;
+
+	array = self.customKillstreaks;
+	player_streak = self.pers["cur_kill_streak"];
+
+	foreach ( hardpoint in array )
+	{
+		if ( getdvarint( "scr_game_forceuav" ) && hardpoint == "radar_mp" )
+			continue;
+
+		killstreak_cost = level.hardpointitems[hardpoint];
+
+		if ( self maps\mp\_utility::_hasPerk( "specialty_hardline" ) )
+			killstreak_cost--;
+
+		if ( player_streak == killstreak_cost )
+		{
+			thread givehardpoint( hardpoint, player_streak );
+			break;
+		}
+	}
+}
+
+givehardpoint( streakName, streakCost )
+{
+	self notify( "giveHardpoint" );
+	self endon( "giveHardpoint" );
+	self endon( "disconnect" );
+	self endon( "death" );
+
+	if ( level.gameended && level.gameendtime != gettime() )
+		return;
+
+	if ( !maps\mp\_utility::is_true( level.killstreaksenabled ) )
+		return;
+
+	if ( getdvar( "scr_game_hardpoints" ) != "" && getdvarint( "scr_game_hardpoints" ) == 0 )
+		return;
+
+	if ( !isdefined( level.hardpointitems[streakName] ) || !level.hardpointitems[streakName] )
+		return;
+
+	// shuffle existing killstreaks up a notch
+	for( i = self.pers["killstreaks"].size; i >= 0; i-- )	
+		self.pers["killstreaks"][i + 1] = self.pers["killstreaks"][i]; 	
+
+	self.pers["killstreaks"][0] = spawnStruct();
+	self.pers["killstreaks"][0].streakName = streakName;
+
+	self.pers["killstreaks"][0].kID = self.pers["kID"];
+	self.pers["kIDs_valid"][self.pers["kID"]] = true;
+
+	self.pers["kID"]++;
+
+	if ( !isDefined( streakCost ) )
+		self.pers["killstreaks"][0].lifeId = -1;
+	else
+		self.pers["killstreaks"][0].lifeId = self.pers["deaths"];
+
+	self giveHardpointWeapon( streakName );
+	self thread hardpointnotify( streakName, streakCost );
+}
+
+giveHardpointWeapon( streakName )
+{
+	weaponList = self getWeaponsListItems();
+
+	foreach ( item in weaponList )
+	{
+		if ( !h2_isKillstreakActivator( item ) )
+			continue;
+
+		if ( self getCurrentWeapon() == item )
+			continue;
+
+		self takeWeapon( item );
+	}
+
+	self giveweapon( streakName );
+	self givemaxammo( streakName );
+	self setactionslot( 4, "weapon", streakName );
+}
+
+giveownedhardpointitem( skipDialog )
+{
+	if ( !isdefined(self.pers["killstreaks"]) || self.pers["killstreaks"].size < 1 )
+		return;
+
+	self giveHardpointWeapon( self.pers["killstreaks"][0].streakName );
+
+	if ( !isDefined( skipDialog ) && !level.inGracePeriod )
+		self maps\mp\_utility::leaderDialogOnPlayer( "achieve_" + self.pers["killstreaks"][0].streakName, "killstreak_earned", 1 );
+}
+
+hardpointitemwaiter()
+{
+	if ( isBot(self) && DISABLE_BOT_KILLSTREAKS )
+		return;
+
+	self endon( "finish_death" );
+	self endon( "disconnect" );
+	level endon( "game_ended" );
+
+	if ( maps\mp\_utility::is_true( level.gameended ) )
+		return;
+
+	if ( self maps\mp\_utility::isEMPed() )
+		self maps\mp\h2_killstreaks\_emp::_setEMPJammed( true );
+
+	if ( isDefined( self.h2_radar_jam ) )
+		self maps\mp\h2_killstreaks\_uav::h2_jamPlayerRadar( true );
+
+	self maps\mp\gametypes\_class::clearcopycatloadout();
+
+	self thread finishDeathWaiter();
+
+	if ( !isBot(self) || !DISABLE_BOT_KILLSTREAKS )
+		self thread waitForChangeTeam();
+
+	if( isDefined( level.onBotSpawned ) )
+		self thread [[level.onBotSpawned]]();
+
+	giveownedhardpointitem();
+
+	for(;;)
+	{		
+		self waittill("weapon_change", newWeapon);
+
+		if ( !isAlive( self ) )
+			continue;
+
+		if ( !isdefined(self.pers["killstreaks"]) || !isdefined(self.pers["killstreaks"][0]) )
+			continue;
+
+		if ( newWeapon != self.pers["killstreaks"][0].streakName )
+			continue;
+
+		waittillframeend;
+
+		streakName = self.pers["killstreaks"][0].streakName;
+		result = self triggerhardpoint();
+
+		if ( result )
+		{
+			logstring( "hardpoint: " + streakName );
+			thread maps\mp\gametypes\_missions::usehardpoint( streakName );
+			self thread [[ level.onxpevent ]]( "hardpoint" );
+			self thread shuffleKillStreaksFILO( streakName );
+		}
+
+		//no force switching weapon for ridable killstreaks
+		if ( !isRideKillstreak( streakName ) || !result )
+		{
+			if ( isAnimateKillstreak( streakName ) )
+			{
+				common_scripts\utility::_disableweaponswitch();
+				common_scripts\utility::waittill_notify_or_timeout_return( "weapon_change", 0.75 );
+				common_scripts\utility::_enableweaponswitch();
+
+				if ( !result )
+					self giveWeapon( streakName );
+			}
+
+			lastWeapon = self common_scripts\utility::getLastWeapon();
+			firstPrimary = self maps\mp\h2_killstreaks\_common::getFirstPrimaryWeapon();
+
+			if ( self hasWeapon( lastWeapon ) )
+				self switchToWeapon( lastWeapon );			
+			else
+				self switchToWeapon( firstPrimary );
+		}
+
+		// give time to switch to the near weapon; when the weapon is none (such as during a "disableWeapon()" period
+		// re-enabling the weapon immediately does a "weapon_change" to the killstreak weapon we just used.  In the case that 
+		// we have two of that killstreak, it immediately uses the second one
+		if ( self getCurrentWeapon() == "none" )
+		{
+			while ( self getCurrentWeapon() == "none" )
+				wait ( 0.05 );
+
+			waittillframeend;
+		}
+	}
+}
+
+finishDeathWaiter()
+{
+	self endon ( "disconnect" );
+
+	self waittill ( "death" );
+
+	wait ( 0.05 );
+	self notify ( "finish_death" );
+}
+
+isRideKillstreak( streakName )
+{
+	switch( streakName )
+	{
+	case "chopper_gunner_mp":
+	case "ac130_mp":
+	case "predator_mp":
+		return true;
+	default:
+		return false;
+	}
+}
+
+isAnimateKillstreak( streakName )
+{
+	switch( streakName )
+	{
+	case "radar_mp":
+	case "counter_radar_mp":
+	case "helicopter_mp":
+	case "nuke_mp":
+	case "emp_mp":
+	case "pavelow_mp":
+	case "dogs_mp":
+		return true;
+	default:
+		return false;
+	}
+}
+
+hardpointnotify( var_0, var_1 )
+{
+	thread maps\mp\_events::earnedkillstreakevent( var_0, var_1 );
+	maps\mp\_utility::leaderdialogonplayer( "achieve_" + var_0, "killstreak_earned", 1 );
+}
+
+killstreakearned( var_0 )
+{
+	if ( var_0 == "radar_mp" )
+		self.firstkillstreakearned = gettime();
+	else if ( isdefined( self.firstkillstreakearned ) && var_0 == "helicopter_mp" )
+	{
+		if ( gettime() - self.firstkillstreakearned < 20000 )
+			thread maps\mp\gametypes\_missions::genericchallenge( "wargasm" );
+	}
+}
+
+//this overwrites killstreak at index 0 and decrements all other killstreaks (FCLS style)
+shuffleKillStreaksFILO( streakName )
+{
+	self setActionSlot( 4, "" );
+
+	arraySize = self.pers["killstreaks"].size;
+
+	streakIndex = -1;
+	for ( i = 0; i < arraySize; i++ )
+	{
+		if ( self.pers["killstreaks"][i].streakName != streakName )
+			continue;
+
+		streakIndex = i;
+		break;
+	}
+	assert( streakIndex >= 0 );
+
+	self.pers["killstreaks"][streakIndex] = undefined;
+
+	for( i = streakIndex + 1; i < arraySize; i++ )	
+	{
+		if ( i == arraySize - 1 ) 
+		{	
+			self.pers["killstreaks"][i-1] = self.pers["killstreaks"][i];
+			self.pers["killstreaks"][i] = undefined;
+		}	
+		else
+		{
+			self.pers["killstreaks"][i-1] = self.pers["killstreaks"][i];
+		}	
+	}
+
+	giveownedhardpointitem();
+}
+
+triggerhardpoint()
+{
+	if( !maps\mp\_utility::gameFlag("prematch_done" ) )
+		return ( false );
+
+	if ( self maps\mp\_utility::isEMPed() )
+	{
+		self iprintlnbold( &"LUA_KS_UNAVAILABLE_EMP_FOR_N", level.empTimeRemaining );
+		return ( false );
+	}
+
+	streakName = self.pers["killstreaks"][0].streakName;
+	lifeId = self.pers["killstreaks"][0].lifeId;
+	kID = self.pers["killstreaks"][0].kID;
+
+	if ( level.killstreakrounddelay )
+	{
+		var_1 = 0;
+
+		if ( isdefined( level.prematch_done_time ) )
+			var_1 = ( gettime() - level.prematch_done_time ) / 1000;
+
+		if ( var_1 < level.killstreakrounddelay )
+		{
+			var_2 = int( level.killstreakrounddelay - var_1 + 0.5 );
+
+			if ( !var_2 )
+				var_2 = 1;
+
+			self iprintlnbold( &"MP_UNAVAILABLE_FOR_N", var_2 );
+			return 0;
+		}
+	}
+
+	if ( !isDefined( level.killstreakfuncs[streakName] ) )
+		return ( false );
+
+	if ( !self isOnGround() )
+		return ( false );
+
+	if ( self maps\mp\_utility::isUsingRemote() )
+		return ( false );
+
+	if ( isDefined( self.selectingLocation ) )
+		return ( false );
+
+	if ( self IsUsingTurret() )
+	{
+		self iprintlnbold( &"LUA_KS_UNAVAILABLE_TURRET" );
+		return ( false );
+	}
+
+	if ( isDefined( self.lastStand ) )
+	{
+		self iprintlnbold( &"LUA_KS_UNAVAILABLE_LASTSTAND" );
+		return ( false );
+	}
+
+	if ( !self common_scripts\utility::isWeaponEnabled() )
+		return ( false );
+
+	if ( isSubStr( streakName, "airdrop" ) )
+		result = self [[level.killstreakfuncs[streakName]]]( lifeId, kID ); 
+	else
+		result = self [[level.killstreakfuncs[streakName]]]( lifeId );
+
+	if ( result )
+		self killstreakLeaderDialog( streakName );
+
+	return result;
+}
+
+killstreakLeaderDialog( streakName )
+{
+	friendlyDialog = "use_" + streakName;
+	enemyDialog = "enemy_" + streakName;
+
+	foreach( player in level.players )
+	{
+		if ( player.team == "spectator" )
+			continue;
+
+		if ( (level.teamBased && player.team == self.team) || (!level.teamBased && player == self) )
+			player maps\mp\_utility::leaderDialogOnPlayer( friendlyDialog );
+		else
+			player maps\mp\_utility::leaderDialogOnPlayer( enemyDialog );
+	}
+}
+
+killstreakhit( var_0, var_1, var_2 )
+{
+	if ( isdefined( var_1 ) && isplayer( var_0 ) && isdefined( var_2.owner ) && isdefined( var_2.owner.team ) )
+	{
+		if ( ( level.teambased && var_2.owner.team != var_0.team || !level.teambased ) && var_0 != var_2.owner )
+		{
+			if ( maps\mp\_utility::iskillstreakweapon( var_1 ) )
+				return;
+
+			if ( !isdefined( var_0.lasthittime[var_1] ) )
+				var_0.lasthittime[var_1] = 0;
+
+			if ( var_0.lasthittime[var_1] == gettime() )
+				return;
+
+			var_0.lasthittime[var_1] = gettime();
+			var_0 thread maps\mp\gametypes\_gamelogic::threadedsetweaponstatbyname( var_1, 1, "hits" );
+			var_3 = var_0 maps\mp\gametypes\_persistence::statgetbuffered( "totalShots" );
+			var_4 = var_0 maps\mp\gametypes\_persistence::statgetbuffered( "hits" ) + 1;
+
+			if ( var_4 <= var_3 )
+			{
+				var_0 maps\mp\gametypes\_persistence::statsetbuffered( "hits", var_4 );
+				var_0 maps\mp\gametypes\_persistence::statsetbuffered( "misses", int( var_3 - var_4 ) );
+				var_5 = clamp( float( var_4 ) / float( var_3 ), 0.0, 1.0 ) * 10000.0;
+				var_0 maps\mp\gametypes\_persistence::statsetbuffered( "accuracy", int( var_5 ) );
+			}
+		}
+	}
+}
+
+playerhasuavactive()
+{
+	if ( level.teambased )
+	{
+		if ( level.activeuavs[self.team] > 0 )
+			return 1;
+	}
+	else if ( level.activeuavs[self.guid] > 0 )
+		return 1;
+
+	return 0;
+}
+
+useradaritem()
+{
+	self maps\mp\h2_killstreaks\_uav::useUAV( "uav" );
+}
+
+getAirstrikeDanger( point )
+{
+	return self maps\mp\h2_killstreaks\_airstrike::getAirstrikeDanger( point );
+}

--- a/user_scripts/mp/enable_bot_killstreaks/enable_bot_killstreaks.gsc
+++ b/user_scripts/mp/enable_bot_killstreaks/enable_bot_killstreaks.gsc
@@ -1,0 +1,410 @@
+//modified by SlyElliot
+#include scripts\utility;
+#include maps\mp\gametypes\_hardpoints;
+#include scripts\mp\bot_patches;
+
+#define DISABLE_BOT_KILLSTREAKS 0
+
+
+h2_setCustomKillstreaks()
+{
+	index_0 = self getPlayerData( "rankedMatchData", "sosRating" );
+	index_1 = self getPlayerData( "rankedMatchData", "gdfVariance" );
+	index_2 = self getPlayerData( "rankedMatchData", "gdfRating" );
+
+	if( isBot( self ) )
+	{
+		if( !DISABLE_BOT_KILLSTREAKS )
+		{
+			self.customKillstreaks = [];
+			self scripts\mp\bot_patches::h2_set_bot_ks();
+		}
+	}
+	else
+	{
+		self.customKillstreaks = [];
+		self.customKillstreaks[0] = h2_getStreakNameFromIndex( index_0, 0 );
+		self.customKillstreaks[1] = h2_getStreakNameFromIndex( index_1, 1 );
+		self.customKillstreaks[2] = h2_getStreakNameFromIndex( index_2, 2 );
+	}
+
+	for ( i = 1; i < self.customKillstreaks.size; i++ ) //order the killstreaks by their cost
+	{
+		streakName = self.customKillstreaks[i];
+		streakCost = level.hardpointitems[streakName];
+
+		for ( j = i - 1; j >= 0 && streakCost < level.hardpointitems[self.customKillstreaks[j]]; j-- )
+			self.customKillstreaks[j + 1] = self.customKillstreaks[j];
+
+		self.customKillstreaks[j + 1] = streakName;
+	}
+}
+
+main()
+{
+	// register custom streaks for bots
+	replacefunc(maps\mp\bots\_bots_ks::bot_killstreak_setup, ::bot_killstreak_setup_stub);
+
+	// use killstreaks persistent variable instead of hardPointItem
+	replacefunc(maps\mp\bots\_bots_ks::bot_think_killstreak, ::bot_think_killstreak_stub);
+	replacefunc(maps\mp\bots\_bots_util::bot_in_combat, ::bot_in_combat_stub);
+}
+
+bot_in_combat_stub( var_0 )
+{
+	if( !isDefined( self.last_enemy_sight_time ) )
+		return 0;
+
+	if ( self.last_enemy_sight_time == 0 )
+		return 0;
+
+	var_1 = gettime() - self.last_enemy_sight_time;
+	var_2 = level.bot_out_of_combat_time;
+
+	if ( isdefined( var_0 ) )
+		var_2 = var_0;
+
+	return var_1 < var_2;
+}
+
+bot_killstreak_setup_stub()
+{
+	if (!isdefined(level.killstreak_botfunc))
+	{
+		bot_register_killstreak_func("radar_mp", maps\mp\bots\_bots_ks::bot_killstreak_simple_use, maps\mp\bots\_bots_ks::bot_can_use_uav);
+		bot_register_killstreak_func("airstrike_mp", ::bot_killstreak_choose_loc_enemies, maps\mp\bots\_bots_ks::bot_can_use_airstrike);
+		bot_register_killstreak_func("helicopter_mp", maps\mp\bots\_bots_ks::bot_killstreak_simple_use, maps\mp\bots\_bots_ks::bot_can_use_helicopter);
+
+		// h2m changes
+		bot_register_killstreak_func("counter_radar_mp", maps\mp\bots\_bots_ks::bot_killstreak_simple_use, ::bot_killstreak_do_use);
+		bot_register_killstreak_func("sentry_mp", maps\mp\bots\_bots_ks::bot_killstreak_simple_use, ::bot_killstreak_do_use);
+		bot_register_killstreak_func("harrier_airstrike_mp", ::bot_killstreak_choose_loc_enemies, maps\mp\bots\_bots_ks::bot_can_use_airstrike);
+		bot_register_killstreak_func("stealth_airstrike_mp", ::bot_killstreak_choose_loc_enemies, maps\mp\bots\_bots_ks::bot_can_use_airstrike);
+		bot_register_killstreak_func("chopper_gunner_mp", maps\mp\bots\_bots_ks::bot_killstreak_simple_use, maps\mp\bots\_bots_ks::bot_can_use_helicopter);
+		bot_register_killstreak_func("ac130_mp", maps\mp\bots\_bots_ks::bot_killstreak_simple_use, ::bot_can_use_ac130);
+		bot_register_killstreak_func("nuke_mp", maps\mp\bots\_bots_ks::bot_killstreak_simple_use, ::bot_killstreak_do_use);
+		bot_register_killstreak_func("emp_mp", maps\mp\bots\_bots_ks::bot_killstreak_simple_use, ::bot_killstreak_do_use);
+		bot_register_killstreak_func("dogs_mp", maps\mp\bots\_bots_ks::bot_killstreak_simple_use, ::bot_killstreak_do_use);
+	}
+}
+
+bot_register_killstreak_func(var_0, var_1, var_2, var_3)
+{
+	if (!isdefined(level.killstreak_botfunc))
+		level.killstreak_botfunc = [];
+
+	level.killstreak_botfunc[var_0] = var_1;
+
+	if (!isdefined(level.killstreak_botcanuse))
+		level.killstreak_botcanuse = [];
+
+	level.killstreak_botcanuse[var_0] = var_2;
+
+	if (!isdefined(level.killstreak_botparm))
+		level.killstreak_botparm = [];
+
+	// add isdefined check here
+	if (isdefined(var_3))
+		level.killstreak_botparm[var_0] = var_3;
+
+	if (!isdefined(level.bot_supported_killstreaks))
+		level.bot_supported_killstreaks = [];
+
+	level.bot_supported_killstreaks[level.bot_supported_killstreaks.size] = var_0;
+}
+
+bot_think_killstreak_stub()
+{
+	self notify("bot_think_killstreak");
+	self endon("bot_think_killstreak");
+	self endon("death");
+	self endon("disconnect");
+	level endon("game_ended");
+
+	while (!isdefined(level.killstreak_botfunc))
+		wait 0.05;
+
+	for (;;)
+	{
+		wait(randomfloatrange(2.0, 4.0));
+
+		if (maps\mp\bots\_bots_util::bot_allowed_to_use_killstreaks())
+		{
+			var_0 = self.pers["killstreaks"];
+
+			// TODO: is this bandaid fix okay? this is technically CptPrice changes here that im patching
+			if (isdefined(var_0) && var_0.size > 1)
+			{
+				var_0 = var_0[0].streakName;
+
+				if (isdefined(self.bot_killstreak_wait) && isdefined(self.bot_killstreak_wait[var_0]) && gettime() < self.bot_killstreak_wait[var_0])
+					continue;
+
+				var_1 = level.killstreak_botcanuse[var_0];
+
+				if (isdefined(var_1) && !self [[ var_1 ]](var_0))
+					continue;
+
+				var_2 = level.killstreak_botfunc[var_0];
+
+				if (isdefined(var_2))
+				{
+					var_3 = self [[ var_2 ]](var_0, var_1);
+
+					if (!isdefined(var_3) || var_3 == 0)
+					{
+						if (!isdefined(self.bot_killstreak_wait))
+							self.bot_killstreak_wait = [];
+
+						self.bot_killstreak_wait[var_0] = gettime() + 5000;
+					}
+				}
+				else
+				{
+
+				}
+			}
+		}
+	}
+}
+
+bot_killstreak_choose_loc_enemies(var_0, var_1)
+{
+	wait(randomintrange( 3, 5 ));
+
+	if ( !maps\mp\bots\_bots_util::bot_allowed_to_use_killstreaks() )
+		return;
+
+	if ( isdefined( var_1 ) && !self [[ var_1 ]]( var_0 ) )
+		return 0;
+
+	self botsetflag( "disable_movement", 1 );
+	maps\mp\bots\_bots_ks::bot_switch_to_killstreak_weapon( var_0 );
+	wait 2.0;
+
+	if ( !isdefined( self.selectinglocation ) )
+	{
+		self botsetflag( "disable_movement", 0 );
+		return;
+	}
+
+	targets = [];
+	foreach (player in level.players)
+	{
+		if (self != player || (level.teambased && self.team != player.team))
+		{
+			targets[targets.size] = player;
+		}
+	}
+
+	random_target = targets[randomint(targets.size)];
+	if( !isdefined(random_target) )
+		random_target = self;
+
+	heightEnt = getent( "airstrikeheight", "targetname" );
+	if( isdefined(heightEnt) || isdefined(level.airstrikeHeightScale) )
+		height = maps\mp\h2_killstreaks\_airdrop::getFlyHeightOffset(random_target.origin);
+	else
+		height = level.heli_leave_nodes[randomInt(level.heli_leave_nodes.size)].origin[2];
+
+	location = ( random_target.origin[0], random_target.origin[1], height );	
+
+	self notify( "confirm_location", location, randomInt(360) );
+	self waittill( "stop_location_selection" );
+	wait 1.0;
+	self botsetflag( "disable_movement", 0 );
+}
+
+// custom streaks
+bot_can_use_ac130(var_0)
+{
+	return (isdefined(level.ac130inuse) && !level.ac130inuse);
+}
+
+bot_killstreak_do_use(var_0)
+{
+	return 1;
+}
+
+// bot ks funcs
+h2_set_bot_ks()
+{
+	switch(randomInt(4))
+	{
+	case 0:
+		self.customKillstreaks[0] = "radar_mp";
+		self.customKillstreaks[1] = "airstrike_mp";
+		self.customKillstreaks[2] = "helicopter_mp";
+		break;
+
+	case 1:
+		self.customKillstreaks[0] = "counter_radar_mp";
+		self.customKillstreaks[1] = "sentry_mp";
+		self.customKillstreaks[2] = "harrier_airstrike_mp";
+		break;
+
+	case 2:
+		self.customKillstreaks[0] = "radar_mp";
+		self.customKillstreaks[1] = "stealth_airstrike_mp";
+		self.customKillstreaks[2] = "chopper_gunner_mp";
+		break;
+
+	case 3:
+		self.customKillstreaks[0] = "counter_radar_mp";
+		self.customKillstreaks[1] = "ac130_mp";
+		self.customKillstreaks[2] = "emp_mp";
+		break;
+
+	default:
+		break;
+	}
+}
+
+bot_remote_use(vehicle)
+{
+	level endon("game_ended");
+	self endon("disconnect");
+
+	self notify("bot_remote_use");
+	self endon("bot_remote_use");
+
+	self BotSetFlag("disable_rotation", true);	
+	lastAimAt = undefined;
+	times = 0;
+
+	wait 3;
+
+	while(self maps\mp\_utility::isUsingRemote())
+	{
+		wait 0.05;
+
+		self.aimAt = undefined;
+		eyePos = vehicle.origin;
+
+		if(isDefined(lastAimAt))
+		{
+			bodyAngles = VectorToAngles(lastAimAt - eyePos);
+			self _setPlayerAngles(bodyAngles);
+			self BotPressButton("attack");
+
+			self.aimAt = lastAimAt;
+			times++;
+
+			if(times == 3)
+			{
+				times = 0;
+				lastAimAt = undefined;
+				wait 0.05;
+			}
+
+			wait 0.05;
+			continue;
+		}
+
+		foreach(player in level.players)
+		{
+			if(player == self)
+				continue;
+
+			if(!maps\mp\_utility::isReallyAlive(player))
+				continue;
+
+			if(level.teamBased && self.pers["team"] == player.pers["team"])
+				continue;
+
+			if(!bulletTracePassed(eyePos, player getTagOrigin("tag_eye"), false, self))
+				continue;
+
+			if(isDefined(self.aimAt))
+			{
+				if(closer(eyePos, player getTagOrigin("j_mainroot"), self.aimAt getTagOrigin("j_mainroot")))
+					self.aimAt = player;
+			}
+			else
+			{
+				self.aimAt = player;
+			}
+		}
+
+		if(isDefined(self.aimAt))
+		{
+			spine = self.aimAt getTagOrigin("j_spineupper");
+			angles = VectorToAngles((spine) - (eyePos));
+
+			self _setPlayerAngles(angles);
+			self BotPressButton("attack");
+
+			if(!isDefined(self.aimAt) || !maps\mp\_utility::isReallyAlive(self.aimAt))
+			{
+				lastAimAt = spine;
+			}
+		}
+	}
+
+	self BotSetFlag("disable_rotation", false);
+}
+
+_setPlayerAngles(Angle)
+{
+	level endon("game_ended");
+	self endon("disconnect");
+	self endon("death");
+
+	Steps = 4;
+	Delay = 0.05;
+	originalAngle = Angle;
+
+	PStepAngle=180/Steps;
+	NStepAngle=PStepAngle-(PStepAngle*2); //Try tweaking the 180 into 360
+	myAngle=self getPlayerAngles();
+	myAngle=NormalizeAngles(myAngle);
+	Angle=NormalizeAngles(Angle);
+
+	X=(Angle[0]-myAngle[0])/Steps;
+	if((myAngle[0]+(X*Steps))>360||X>36||X<-36)
+	{
+		X=(myAngle[0]-((myAngle[0]+(X*Steps))-360))/Steps;X=X-(X*2);
+	}
+
+	Y=(Angle[1]-myAngle[1])/Steps;
+	if((myAngle[1]+(Y*Steps))>360||Y>36||Y<-36)
+	{
+		Y=(myAngle[1]-((myAngle[1]+(Y*Steps))-360))/Steps;Y=Y-(Y*2);
+	}
+
+	if((X<PStepAngle&&X>NStepAngle)&&(Y<PStepAngle&&Y>NStepAngle))
+	{
+		for(i=1;i<Steps;i++)
+		{
+			newAngle=(myAngle[0]+X,myAngle[1]+Y,0);
+			self setPlayerAngles(newAngle);
+			myAngle=self getPlayerAngles();
+			wait Delay;
+		}
+
+		self setPlayerAngles(originalAngle);
+		return 1;
+	}
+
+	wait Delay;
+	self setPlayerAngles(originalAngle);
+	return 0;
+}
+
+NormalizeAngles(Angle)
+{
+	X=Angle[0];
+	Y=Angle[1];
+	Z=Angle[2];
+	if(X<0)X=Angle[0]+360;
+	if(Y<0)Y=Angle[1]+360;
+	if(Z<0)Z=Angle[2]+360;
+	if(X>360)
+		X=Angle[0]-360;
+	if(Y>360)
+		Y=Angle[1]-360;
+	if(Z>360)
+		Z=Angle[2]-360;
+
+	return (X,Y,Z);
+}

--- a/user_scripts/mp/nuke_to_moab_patch_v2.2.1 Infinite+NoNukeVision.gsc
+++ b/user_scripts/mp/nuke_to_moab_patch_v2.2.1 Infinite+NoNukeVision.gsc
@@ -1,0 +1,256 @@
+// Created by Xevrac
+// Modify NUKE to MOAB style 
+// Use DVAR nukeEndsGame to 0 for no endgame nuke like MW3 MOAB
+// Version 2.1.1
+
+//Infinite nukes patch by Sly Elliot
+
+#include scripts\utility;
+#include common_scripts\utility;
+#include maps\mp\_utility;
+#include maps\mp\gametypes\_hud_util;
+#include maps\mp\gametypes\_gamelogic;
+#include maps\mp\h2_killstreaks\_nuke;
+
+init()
+{
+    setDvarIfUninitialized("nukeEndsGame", 1);
+
+    replaceFunc(maps\mp\h2_killstreaks\_nuke::nukeDeath, ::customNukeDeath);
+    replaceFunc(maps\mp\h2_killstreaks\_nuke::cancelNukeOnDeath, ::customCancelNukeOnDeath);
+    replaceFunc(maps\mp\h2_killstreaks\_nuke::nukeEffects, ::customNukeEffects);
+    replaceFunc(maps\mp\h2_killstreaks\_nuke::doNuke, ::customDoNuke);
+
+
+    // For use with giveNuke
+    // Test thread
+
+    // thread onPlayerConnect();
+}
+
+// For use with giveNuke
+// Test function
+
+// onPlayerConnect()
+// {
+//     level endon("game_ended");
+//     for(;;)
+//     {
+//         level waittill("connected", player);
+//         player thread onPlayerSpawned();
+//     }
+// }
+
+// giveNuke onPlayerSpawned
+// Test function
+
+// onPlayerSpawned()
+// {
+//     self endon("disconnect");
+//     level endon("game_ended");
+
+//     for(;;)
+//     {
+//         self waittill("spawned_player");
+        
+
+
+//         self thread giveNuke();
+//     }
+// }
+
+customNukeSlowMo()
+{
+	level endon ( "nuke_cancelled" );
+
+	foreach( player in level.players )
+	{
+		if ( isReallyAlive(player) )
+			earthquake( 0.6, 10, player.origin, 1000 );
+	}
+
+	// Start slow motion effect
+	setSlowMotion( 1.0, 0.25, 0.5 );
+
+	// Wait for the nuke death event
+	level waittill( "nuke_death" );
+
+	// Reset to normal speed
+	setSlowMotion( 1.0, 1.0, 0.0 );
+
+	// Ensure global reset after the nuke
+	level thread resetGameSpeed();
+}
+
+/*
+customNukeVision()
+{
+	level endon ( "nuke_cancelled" );
+
+	level.nukeVisionInProgress = true;
+	_visionsetnaked( "", 0 );
+	visionSetPostApply( "airlift_nuke_flash", 2 );
+
+	level waittill( "nuke_death" );
+
+	_visionsetnaked( "", 0 );
+	visionSetPostApply( "", 0 );
+	wait 5;
+	_visionsetnaked( "", 0 );
+	level.nukeVisionInProgress = false;
+}
+*/
+
+resetGameSpeed()
+{
+	// Safety delay to ensure all nuke effects have played out
+	wait( 4.0 );
+
+	// Ensure the game is back to normal speed
+	setSlowMotion( 1.0, 1.0, 0.0 );
+}
+
+customDoNuke( allowCancel )
+{
+	level endon ( "nuke_cancelled" );
+
+	level.nukeInfo = spawnStruct();
+	level.nukeInfo.player = self;
+	level.nukeInfo.team = self.pers["team"];
+	level.nukeinfo.xpscalar = 1;
+
+	level.nukeIncoming = true;
+
+	h2_nukeCountdown();
+
+	if ( level.teambased )
+	{
+		thread teamPlayerCardSplash( "callout_used_nuke", self, self.team );
+	}
+	else
+	{
+		if ( !level.hardcoreMode )
+			self iprintlnbold( &"LUA_KS_TNUKE" );
+	}
+
+	level thread delaythread_nuke( (level.nukeTimer - 3.3), ::nukeSoundIncoming );
+	level thread delaythread_nuke( level.nukeTimer, ::nukeSoundExplosion );
+	level thread delaythread_nuke( level.nukeTimer, ::customNukeSlowMo );
+	level thread delaythread_nuke( level.nukeTimer, ::nukeEffects );
+	//level thread delaythread_nuke( (level.nukeTimer + 0.25), ::customNukeVision );
+	level thread delaythread_nuke( (level.nukeTimer + 1.5), ::nukeDeath );
+	level thread delaythread_nuke( (level.nukeTimer + 1.5), ::nukeEarthquake );
+	level thread nukeAftermathEffect();
+
+	if ( level.cancelMode && allowCancel )
+		level thread cancelNukeOnDeath( self ); 
+
+	// leaks if lots of nukes are called due to endon above.
+	clockObject = spawn( "script_origin", (0,0,0) );
+	clockObject hide();
+
+	while ( !isDefined( level.nukeDetonated ) )
+	{
+		clockObject playSound( "h2_nuke_timer" );
+		wait( 1.0 );
+	}
+}
+
+customNukeEffects()
+{
+	level endon ( "nuke_cancelled" );
+
+	level.nukeCountdownTimer destroy();
+	level.nukeCountdownIcon destroy();
+
+	level.nukeDetonated = true;
+	level maps\mp\h2_killstreaks\_emp::destroyActiveVehicles( level.nukeInfo.player );
+
+	foreach( player in level.players )
+	{
+		playerForward = anglestoforward( player.angles );
+		playerForward = ( playerForward[0], playerForward[1], 0 );
+		playerForward = VectorNormalize( playerForward );
+
+		nukeDistance = 5000;
+
+		nukeEnt = Spawn( "script_model", player.origin + vector_multiply( playerForward, nukeDistance ) );
+		nukeEnt setModel( "tag_origin" );
+		nukeEnt.angles = ( 0, (player.angles[1] + 180), 90 );
+
+		nukeEnt thread nukeEffect( player );
+		player.nuked = true;
+	}
+}
+
+customNukeDeath()
+{
+    level endon("nuke_cancelled");
+    level notify("nuke_death");
+
+    maps\mp\gametypes\_hostmigration::waitTillHostMigrationDone();
+    AmbientStop(1);
+
+    nukeEndsGame = getDvarInt("nukeEndsGame");
+
+    if (nukeEndsGame == 1)
+    {
+        foreach (player in level.players)
+        {
+            if (isAlive(player))
+                player thread maps\mp\gametypes\_damage::finishPlayerDamageWrapper(level.nukeInfo.player, level.nukeInfo.player, 999999, 0, "MOD_EXPLOSIVE", "nuke_mp", player.origin, player.origin, "none", 0, 0);
+        }
+
+        if (level.teamBased)
+            thread maps\mp\gametypes\_gamelogic::endGame(level.nukeInfo.team, game["strings"]["nuclear_strike"], true);
+        else
+        {
+            if (isDefined(level.nukeInfo.player))
+                thread maps\mp\gametypes\_gamelogic::endGame(level.nukeInfo.player, game["strings"]["nuclear_strike"], true);
+            else
+                thread maps\mp\gametypes\_gamelogic::endGame(level.nukeInfo, game["strings"]["nuclear_strike"], true);
+        }
+    }
+    else if (nukeEndsGame == 0)
+    {
+        foreach (player in level.players)
+        {
+            if (isAlive(player))
+                player thread maps\mp\gametypes\_damage::finishPlayerDamageWrapper(level.nukeInfo.player, level.nukeInfo.player, 999999, 0, "MOD_EXPLOSIVE", "nuke_mp", player.origin, player.origin, "none", 0, 0);
+                player thread customCancelNukeOnDeath(player);
+        }
+    }
+}
+
+
+customCancelNukeOnDeath(player)
+{
+    player waittill_any("death", "disconnect");
+
+    if (isDefined(player) && level.cancelMode == 2)
+        player thread maps\mp\h2_killstreaks\_emp::h2_EMP_Use(0, 0);
+
+    maps\mp\gametypes\_gamelogic::resumeTimer();
+    level.timeLimitOverride = false;
+
+    level.nukeDetonated = undefined;
+    level.nukeInfo = undefined;
+    level.nukeIncoming = undefined;
+    player.nuked = undefined;
+
+    level.nukeCountdownTimer destroy();
+    level.nukeCountdownIcon destroy();
+
+    level notify("nuke_cancelled");
+}
+
+// For testing only 
+// Gives player nuke onSpawn
+// Don't use in prod servers or expect chaos!
+
+// giveNuke()
+// {
+//     wait 1;
+
+//     self maps\mp\gametypes\_hardpoints::giveHardpoint("nuke_mp", 25);
+// }

--- a/user_scripts/mp/wip/fix_weapon_pickups.gsc
+++ b/user_scripts/mp/wip/fix_weapon_pickups.gsc
@@ -1,0 +1,119 @@
+//modified by SlyElliot
+#include scripts\utility;
+#include maps\mp\gametypes\_weapons;
+
+
+dropweaponfordeath( var_0, var_1 )
+{
+    if ( !maps\mp\_utility::isusingremote() )
+        waittillframeend;
+
+    if ( isdefined( level.blockweapondrops ) )
+        return;
+
+    if ( !isdefined( self ) )
+        return;
+
+    if ( isdefined( self.droppeddeathweapon ) )
+        return;
+
+    if ( level.ingraceperiod )
+        return;
+
+    var_2 = self.lastdroppableweapon;
+
+    if ( !isdefined( var_2 ) )
+        return;
+
+    if ( var_2 == "none" )
+        return;
+
+    if ( !self hasweapon( var_2 ) )
+        return;
+
+    if ( maps\mp\_utility::isjuggernaut() )
+        return;
+
+    if ( isdefined( level.gamemodemaydropweapon ) && !self [[ level.gamemodemaydropweapon ]]( var_2 ) )
+        return;
+
+    var_3 = maps\mp\_utility::getweaponnametokens( var_2 );
+
+    if ( var_3[0] == "alt" )
+    {
+        for ( var_4 = 0; var_4 < var_3.size; var_4++ )
+        {
+            if ( var_4 > 0 && var_4 < 2 )
+            {
+                var_2 += var_3[var_4];
+                continue;
+            }
+
+            if ( var_4 > 0 )
+            {
+                var_2 += ( "_" + var_3[var_4] );
+                continue;
+            }
+
+            var_2 = "";
+        }
+    }
+
+     if ( var_2 != "riotshield_mp" )
+    {
+        if ( !self anyammoforweaponmodes( var_2 ) )
+            return;
+
+        var_5 = self getweaponammoclip( var_2, "right" );
+        var_6 = self getweaponammoclip( var_2, "left" );
+
+        if ( !var_5 && !var_6 )
+            return;
+
+        var_7 = self getweaponammostock( var_2 );
+        var_8 = weaponmaxammo( var_2 );
+
+        if ( var_7 > var_8 )
+            var_7 = var_8;
+
+        var_9 = self dropitem( var_2 );
+
+        if ( !isdefined( var_9 ) )
+            return;
+
+        // Adjust position slightly to prevent clipping into the ground
+        var_9.origin = ( var_9.origin[0], var_9.origin[1], var_9.origin[2] + 10 );
+
+        if ( maps\mp\_utility::ismeleemod( var_1 ) )
+            var_9.origin = ( var_9.origin[0], var_9.origin[1], var_9.origin[2] + 10 );
+
+        var_9 itemweaponsetammo( var_5, var_7, var_6 );
+    }
+    else
+    {
+        var_9 = self dropitem( var_2 );
+
+        if ( !isdefined( var_9 ) )
+            return;
+
+        var_9 itemweaponsetammo( 1, 1, 0 );
+    }
+
+   // Perform a bullet trace to check for ground level
+    var_trace = bullettrace(var_9.origin, (var_9.origin[0], var_9.origin[1], var_9.origin[2] - 20), false, self);
+    var_hitFraction = var_trace["fraction"];
+    var_hitPosition = var_trace["position"];
+
+    // Adjust weapon position if it is below ground
+    if (var_hitFraction < 1.0) {
+        var_9.origin = (var_hitPosition[0], var_hitPosition[1], var_hitPosition[2] + 10);
+    }
+
+    var_9 itemweaponsetammo( 0, 0, 0, 1 );
+    self.droppeddeathweapon = 1;
+    var_9.owner = self;
+    var_9.ownersattacker = var_0;
+    var_9.targetname = "dropped_weapon";
+    var_9 thread watchpickup();
+    var_9 thread deletepickupafterawhile();
+}


### PR DESCRIPTION
Enable bot killstreaks

WIP script to fix weapon drops falling into the floor and not being able to pick up

Infinite amount of nukes can deploy in a single match without game ending or slow-mo breaking, also NukeVision FX filter disabled

These have been playtested in servers and private match and have enhanced the player experience on my servers. I've gotten good feedback on how these additions improve the fun-factor of the game a great deal and bring QoL improvements.