### PR TITLE
drop weapons fix + Infinite Nuke Improvement

### DIFF
--- a/user_scripts/mp/fix_weapon_pickups.gsc
+++ b/user_scripts/mp/fix_weapon_pickups.gsc
@@ -1,0 +1,119 @@
+//modified by SlyElliot
+#include scripts\utility;
+#include maps\mp\gametypes\_weapons;
+
+
+dropweaponfordeath( var_0, var_1 )
+{
+    if ( !maps\mp\_utility::isusingremote() )
+        waittillframeend;
+
+    if ( isdefined( level.blockweapondrops ) )
+        return;
+
+    if ( !isdefined( self ) )
+        return;
+
+    if ( isdefined( self.droppeddeathweapon ) )
+        return;
+
+    if ( level.ingraceperiod )
+        return;
+
+    var_2 = self.lastdroppableweapon;
+
+    if ( !isdefined( var_2 ) )
+        return;
+
+    if ( var_2 == "none" )
+        return;
+
+    if ( !self hasweapon( var_2 ) )
+        return;
+
+    if ( maps\mp\_utility::isjuggernaut() )
+        return;
+
+    if ( isdefined( level.gamemodemaydropweapon ) && !self [[ level.gamemodemaydropweapon ]]( var_2 ) )
+        return;
+
+    var_3 = maps\mp\_utility::getweaponnametokens( var_2 );
+
+    if ( var_3[0] == "alt" )
+    {
+        for ( var_4 = 0; var_4 < var_3.size; var_4++ )
+        {
+            if ( var_4 > 0 && var_4 < 2 )
+            {
+                var_2 += var_3[var_4];
+                continue;
+            }
+
+            if ( var_4 > 0 )
+            {
+                var_2 += ( "_" + var_3[var_4] );
+                continue;
+            }
+
+            var_2 = "";
+        }
+    }
+
+     if ( var_2 != "riotshield_mp" )
+    {
+        if ( !self anyammoforweaponmodes( var_2 ) )
+            return;
+
+        var_5 = self getweaponammoclip( var_2, "right" );
+        var_6 = self getweaponammoclip( var_2, "left" );
+
+        if ( !var_5 && !var_6 )
+            return;
+
+        var_7 = self getweaponammostock( var_2 );
+        var_8 = weaponmaxammo( var_2 );
+
+        if ( var_7 > var_8 )
+            var_7 = var_8;
+
+        var_9 = self dropitem( var_2 );
+
+        if ( !isdefined( var_9 ) )
+            return;
+
+        // Adjust position slightly to prevent clipping into the ground
+        var_9.origin = ( var_9.origin[0], var_9.origin[1], var_9.origin[2] + 10 );
+
+        if ( maps\mp\_utility::ismeleemod( var_1 ) )
+            var_9.origin = ( var_9.origin[0], var_9.origin[1], var_9.origin[2] + 10 );
+
+        var_9 itemweaponsetammo( var_5, var_7, var_6 );
+    }
+    else
+    {
+        var_9 = self dropitem( var_2 );
+
+        if ( !isdefined( var_9 ) )
+            return;
+
+        var_9 itemweaponsetammo( 1, 1, 0 );
+    }
+
+   // Perform a bullet trace to check for ground level
+    var_trace = bullettrace(var_9.origin, (var_9.origin[0], var_9.origin[1], var_9.origin[2] - 20), false, self);
+    var_hitFraction = var_trace["fraction"];
+    var_hitPosition = var_trace["position"];
+
+    // Adjust weapon position if it is below ground
+    if (var_hitFraction < 1.0) {
+        var_9.origin = (var_hitPosition[0], var_hitPosition[1], var_hitPosition[2] + 10);
+    }
+
+    var_9 itemweaponsetammo( 0, 0, 0, 1 );
+    self.droppeddeathweapon = 1;
+    var_9.owner = self;
+    var_9.ownersattacker = var_0;
+    var_9.targetname = "dropped_weapon";
+    var_9 thread watchpickup();
+    var_9 thread deletepickupafterawhile();
+}

--- a/user_scripts/mp/nuke_to_moab_patch_v2.2.1 Infinite+NoNukeVision.gsc
+++ b/user_scripts/mp/nuke_to_moab_patch_v2.2.1 Infinite+NoNukeVision.gsc
@@ -11,6 +11,7 @@
 #include maps\mp\gametypes\_hud_util;
 #include maps\mp\gametypes\_gamelogic;
 #include maps\mp\h2_killstreaks\_nuke;
+#include maps\mp\h2_killstreaks\_emp;
 
 init()
 {
@@ -21,6 +22,21 @@ init()
     replaceFunc(maps\mp\h2_killstreaks\_nuke::nukeEffects, ::customNukeEffects);
     replaceFunc(maps\mp\h2_killstreaks\_nuke::doNuke, ::customDoNuke);
 
+
+	//level._effect[ "emp_flash" ] = loadfx( "fx/explosions/nuke_flash" );
+
+	level.teamEMPed["allies"] = false;
+	level.teamEMPed["axis"] = false;
+	level.empPlayer = undefined;
+
+	if ( level.teamBased )
+		level thread EMP_TeamTracker();
+	else
+		level thread EMP_PlayerTracker();
+
+	level.killstreakFuncs["emp_mp"] = ::h2_EMP_Use;
+
+	level thread onPlayerConnect();
 
     // For use with giveNuke
     // Test thread
@@ -59,6 +75,7 @@ init()
 //     }
 // }
 
+/*
 customNukeSlowMo()
 {
 	level endon ( "nuke_cancelled" );
@@ -81,6 +98,7 @@ customNukeSlowMo()
 	// Ensure global reset after the nuke
 	level thread resetGameSpeed();
 }
+*/
 
 /*
 customNukeVision()
@@ -135,7 +153,7 @@ customDoNuke( allowCancel )
 
 	level thread delaythread_nuke( (level.nukeTimer - 3.3), ::nukeSoundIncoming );
 	level thread delaythread_nuke( level.nukeTimer, ::nukeSoundExplosion );
-	level thread delaythread_nuke( level.nukeTimer, ::customNukeSlowMo );
+	//level thread delaythread_nuke( level.nukeTimer, ::customNukeSlowMo );
 	level thread delaythread_nuke( level.nukeTimer, ::nukeEffects );
 	//level thread delaythread_nuke( (level.nukeTimer + 0.25), ::customNukeVision );
 	level thread delaythread_nuke( (level.nukeTimer + 1.5), ::nukeDeath );
@@ -154,6 +172,7 @@ customDoNuke( allowCancel )
 		clockObject playSound( "h2_nuke_timer" );
 		wait( 1.0 );
 	}
+
 }
 
 customNukeEffects()
@@ -164,13 +183,21 @@ customNukeEffects()
 	level.nukeCountdownIcon destroy();
 
 	level.nukeDetonated = true;
+	
+	level maps\mp\h2_killstreaks\_emp::h2_EMP_Use();
+	
+	//level maps\mp\h2_killstreaks\_emp::_visionsetnaked( "coup_sunmap blind", 0.1 );
+	//thread empEffects();
+	level._effect[ "emp_flash" ] = loadfx( "fx/explosions/nuke_flash" );
+	//level maps\mp\h2_killstreaks\_emp::empEffects();
 	level maps\mp\h2_killstreaks\_emp::destroyActiveVehicles( level.nukeInfo.player );
-
+	//level maps\mp\h2_killstreaks\_emp::EMP_TeamTracker();
 	foreach( player in level.players )
 	{
 		playerForward = anglestoforward( player.angles );
 		playerForward = ( playerForward[0], playerForward[1], 0 );
 		playerForward = VectorNormalize( playerForward );
+		
 
 		nukeDistance = 5000;
 
@@ -179,7 +206,10 @@ customNukeEffects()
 		nukeEnt.angles = ( 0, (player.angles[1] + 180), 90 );
 
 		nukeEnt thread nukeEffect( player );
+		
 		player.nuked = true;
+
+		
 	}
 }
 


### PR DESCRIPTION
I made a script that attempts to fix the issue where weapons dropped on death tend to clip into the ground and be impossible to pick up, the majority of the time.

Its a bit ugly because this makes it so weapons tend to float above the ground to avoid them clipping into the floor but its works the majority of the time to currently at least fix this very frustrating glitch.


Also I made some minor improvements to the infinite nuke script where it adds the EMP flash whent he nuke goes off, removes the Slow-mo effect, and removes the nuke vision. Keeping nukes fun, fast paced, and unpunishing for the entire lobby.