### PR TITLE
Update anticamp.gsc

### DIFF
--- a/user_scripts/mp/anticamp.gsc
+++ b/user_scripts/mp/anticamp.gsc
@@ -10,7 +10,7 @@ main()
 
     // Set default Dvars if not defined
     if (!isDefined(getDvar("campTimeLimit")))
-        setDvar("campTimeLimit", "5");
+        setDvar("campTimeLimit", "20");
     if (!isDefined(getDvar("campDistance")))
         setDvar("campDistance", "100");
 


### PR DESCRIPTION
Updated the default "campTimeLimit" value from 5 to a more reasonable default of 20. To prevent players just falling over in the pre-game timer by default. As always it can be edited when setting the dvar in the server cfg.